### PR TITLE
Added proxy support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,7 @@ class devpi::config (
   $listen_port = $::devpi::listen_port,
   $server_dir  = $::devpi::server_dir,
   $virtualenv  = $::devpi::virtualenv,
+  $proxy       = $::devpi::proxy,
 ) inherits ::devpi::params {
 
   if $::devpi::params::systemd {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,9 @@
 # [*virtualenv*]
 #   Absolute path to sandboxed virtualenv directory. If set package is unmanaged
 #
+# [*proxy*]
+#   HTTP url and port for http_proxy and https_proxy env variables (example: http://proxy.domain.tld:80)
+#
 # === Examples
 #
 # include ::devpi
@@ -77,6 +80,7 @@ class devpi (
   $refresh         = 3600,
   $server_dir      = $::devpi::params::server_dir,
   $virtualenv      = '',
+  $proxy           = $::devpi::params::proxy,
 ) inherits devpi::params {
 
   anchor { '::devpi::start': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@ class devpi::params {
   $package_client = 'devpi-client'
   $service = 'devpi-server'
   $server_dir = '/opt/devpi'
+  $proxy = undef
 
   case $::osfamily {
     redhat: {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -29,7 +29,7 @@ describe 'devpi' do
         if osmaj == 6 then
           it {
             should contain_file('/etc/init/devpi-server.conf')
-              .with_content(/exec su - devpi -c "devpi-server --host 0.0.0.0 --port 3141 --serverdir \/opt\/devpi"\n/)
+              .with_content(/exec sudo -E -u devpi devpi-server --host 0.0.0.0 --port 3141 --serverdir \/opt\/devpi\n/)
           }
           it {
             should_not contain_class('devpi::config').that_notifies('Class[devpi::systemd]')
@@ -64,7 +64,7 @@ describe 'devpi' do
         if osmaj == 6 then
           it {
             should contain_file('/etc/init/devpi-server.conf')
-              .with_content(/exec su - devpi -c "\/venv\/bin\/devpi-server --host 0.0.0.0 --port 3141 --serverdir \/opt\/devpi"\n/)
+              .with_content(/exec sudo -E -u devpi \/venv\/bin\/devpi-server --host 0.0.0.0 --port 3141 --serverdir \/opt\/devpi\n/)
           }
         elsif osmaj == 7 then
           it {

--- a/templates/systemd.service.erb
+++ b/templates/systemd.service.erb
@@ -7,6 +7,10 @@ After=basic.target network.target
 User=<%= @user %>
 Group=<%= @group %>
 ExecStart=<%= @devpi_path %> --host <%= @listen_host %> --port <%= @listen_port %> --serverdir <%= @server_dir %>
+<% if @proxy -%>
+Environment=http_proxy=<%= @proxy %>
+Environment=https_proxy=<%= @proxy %>
+<% end -%>
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/upstart.erb
+++ b/templates/upstart.erb
@@ -4,9 +4,15 @@
 ##################################
 # /etc/init/devpi.conf
 description "devpi"
+<% if @proxy -%>
+env http_proxy=<%= @proxy %>
+env https_proxy=<%= @proxy %>
+export http_proxy
+export https_proxy
+<% end -%>
 
 start on runlevel [2345]
 stop on runlevel [!2345]
 respawn
 
-exec su - <%= @user %> -c "<%- unless @virtualenv.empty? -%><%= @virtualenv %>/bin/<%- end -%>devpi-server --host <%= @listen_host %> --port <%= @listen_port %> --serverdir <%= @server_dir %>"
+exec sudo -E -u <%= @user %> <% unless @virtualenv.empty? %><%= @virtualenv %>/bin/<% end %>devpi-server --host <%= @listen_host %> --port <%= @listen_port %> --serverdir <%= @server_dir %>


### PR DESCRIPTION
- Added `proxy` parameter for use with HTTP proxies
- Tested on RHEL 6 and RHEL 7
- Switched upstart script to use `sudo -E` method (preserves env variables) for running as the `devpi` user (according to http://upstart.ubuntu.com/cookbook/#changing-user both methods are equally wrong and should actually use `start-stop-daemon` but I see no need)
- Updated spec tests
